### PR TITLE
Fix some broken stuff and added hard queue limit

### DIFF
--- a/config/config.yaml.default
+++ b/config/config.yaml.default
@@ -9,4 +9,4 @@ nodes:
   - https://api.openhive.network
 downvote_whitelist: []
 skip_delegator_check: false
-
+hard_queue_limit: 20

--- a/html/api/lib/config.py
+++ b/html/api/lib/config.py
@@ -1,8 +1,22 @@
 import os
 
 from yaml import safe_load
-from munch import munchify
+from munch import munchify, Munch
 
-with open (os.path.join(os.path.split(__file__)[0],
-                        "../../../config/config.yaml"), "r") as f:
+
+_project_root = os.path.join(
+    os.path.split(__file__)[0],
+    "../../../"
+)
+
+with open (os.path.join(_project_root, "config/config.yaml"), "r") as f:
     config = munchify(safe_load(f))
+
+
+def load_credentials():
+    credentials = Munch()
+    with open(os.path.join(_project_root, "credentials.txt")) as credfile:
+        credentials.username = credfile.readline().strip()
+        credentials.posting = credfile.readline().strip()
+        credentials.active = credfile.readline().strip()
+    return credentials

--- a/html/api/lib/errors.py
+++ b/html/api/lib/errors.py
@@ -6,11 +6,10 @@ class CurangelError(RuntimeError):
         name = self.__class__.__name__
         desc = self.fmt()
         return "<{}: {}>".format(name, desc)
-        return self.__class__.__name__
 
     def fmt(self, user=None):
         if user is None:
             user = "user"
         else:
             user = "user '{}'".format(user)
-        return self._fmt().strip().format(user=user, **vars(self))
+        return self._fmt.strip().format(user=user, **vars(self))

--- a/html/api/register
+++ b/html/api/register
@@ -4,6 +4,7 @@
 import cgi
 import os
 import uuid
+import html
 
 from lib import db
 from lib import api
@@ -18,7 +19,7 @@ userhash = form.getvalue('userhash')
 
 userip   = '0.0.0.0'
 if 'REMOTE_ADDR' in os.environ:
-  userip = cgi.escape(os.environ["REMOTE_ADDR"])
+  userip = html.escape(os.environ["REMOTE_ADDR"])
 
 # save a new entry
 if username and userhash:

--- a/html/api/upvote
+++ b/html/api/upvote
@@ -16,15 +16,15 @@ from hive.account import Account
 from lib import db
 from lib import api
 from lib import errorHandler
-from lib.config import config
+from lib.config import config, load_credentials
 
 from lib.rate_limit import Enforcer, RateLimitError
 from lib.db_util import QueueDBHelper
 
 
-credfile = open("../../credentials.txt")
-user = credfile.readline().strip()
-key = credfile.readline().strip()
+credentials = load_credentials()
+user = credentials.username
+key = credentials.posting
 
 client = Hive(keys=[key],nodes=config.nodes)
 chain = Blockchain(client)

--- a/html/api/upvote
+++ b/html/api/upvote
@@ -12,11 +12,13 @@ import json
 from hive.hive import Hive
 from hive.blockchain import Blockchain
 from hive.account import Account
+from sorcery import dict_of
 
 from lib import db
 from lib import api
 from lib import errorHandler
 from lib.config import config, load_credentials
+from lib.notify_hook import notify
 
 from lib.rate_limit import Enforcer, RateLimitError
 from lib.db_util import QueueDBHelper
@@ -168,6 +170,18 @@ else:
     db_path = db.config.db.file
     with QueueDBHelper(db_path) as qdbh:
       queue_length = qdbh.query_queue_length()
+
+
+    # let's not let the queue get out of hand (fix mana someday)
+    if hasattr(config, "hard_queue_limit"):
+      if queue_length >= config.hard_queue_limit:
+        message = f"I'm sorry, {username}; I'm afraid I can't do that. "
+        message += f"\n\n(Queue size would exceed {config.hard_queue_limit}.)"
+        notify("queue-limit", dict_of(
+          username,
+          post=post['url']
+        ))
+        errorHandler.throwError(message)
 
     # check mana
     try:

--- a/src/compilation.py
+++ b/src/compilation.py
@@ -7,14 +7,18 @@ import rfc3987
 from string import ascii_letters, digits
 
 from db import DB
-from config import config
+
+import _cgi_path # noqa: F401
+from config import config, load_credentials
 
 from hive.hive import Hive
 from hive.blockchain import Blockchain
 
-credfile = open("credentials.txt")
-user = credfile.readline().strip()
-key = credfile.readline().strip()
+
+credentials = load_credentials()
+user = credentials.username
+key = credentials.posting
+
 
 db    = DB('curangel.sqlite3')
 client = Hive(keys=[key],nodes=config.nodes)

--- a/src/config.py
+++ b/src/config.py
@@ -1,8 +1,0 @@
-import os
-
-from yaml import safe_load
-from munch import munchify
-
-with open(os.path.join(os.path.split(__file__)[0],
-                       "../config/config.yaml"), "r") as f:
-    config = munchify(safe_load(f))

--- a/src/curangel.py
+++ b/src/curangel.py
@@ -7,7 +7,9 @@ from traceback import format_exc
 from hive.hive import Hive
 
 from voter import Voter
-from config import config
+
+import _cgi_path # noqa: F401
+from config import config, load_credentials
 
 # Print status at least once every this many seconds.
 MONITOR_INTERVAL_SEC = 300
@@ -58,9 +60,9 @@ class Curangel():
         pass
 
 if __name__ == '__main__':
-  credfile = open("credentials.txt")
-  user = credfile.readline().strip()
-  key = credfile.readline().strip()
+  credentials = load_credentials()
+  user = credentials.username
+  key = credentials.posting
 
   curangel = Curangel(user,key)
 

--- a/src/downvotes.py
+++ b/src/downvotes.py
@@ -3,7 +3,9 @@
 import time
 import datetime
 from db import DB
-from config import config
+
+import _cgi_path # noqa: F401
+from config import config, load_credentials
 
 from hive.hive import Hive
 from hive.blockchain import Blockchain
@@ -11,9 +13,9 @@ from hive.blockchain import Blockchain
 ADDED_VALUE_TRAIL = 600
 
 
-credfile = open("credentials.txt")
-bot = credfile.readline().strip()
-key = credfile.readline().strip()
+credentials = load_credentials()
+bot = credentials.username
+key = credentials.posting
 
 db    = DB('curangel.sqlite3')
 client = Hive(keys=[key],nodes=config.nodes)

--- a/src/payout.py
+++ b/src/payout.py
@@ -6,7 +6,9 @@ from time import sleep
 from argparse import ArgumentParser
 
 from db import DB
-from config import config
+
+import _cgi_path # noqa: F401
+from config import config, load_credentials
 
 from hive.hive import Hive
 from hive.account import Account
@@ -17,10 +19,11 @@ _ap = ArgumentParser()
 _ap.add_argument("--test-scan", action="store_true",
                  help="test history scanning function only")
 
-credfile = open("credentials.txt")
-bot = credfile.readline().strip()
-postkey = credfile.readline().strip()
-key = credfile.readline().strip()
+
+credentials = load_credentials()
+bot = credentials.username
+postkey = credentials.posting
+key = credentials.active
 
 db    = DB('curangel.sqlite3')
 client = Hive(keys=[key],nodes=config.nodes)


### PR DESCRIPTION
There have been some (warranted) complaints about sloppy observation of our queue length guideline of 20. Alas, this means that, as it generally goes with this sort of thing, the time has come to replace the guideline with a code change.

Broken stuff fixed:
- mana check exceptions were throwing exceptions while being excepted (inxception? and/or "yo dawg")
- `cgi.escape` removed in Python 3.8; replaced with `html.escape`

Miscellany:
- factored out credential loading to `config` module